### PR TITLE
Target java 1.8

### DIFF
--- a/zipkin-datadog-reporter-parent/pom.xml
+++ b/zipkin-datadog-reporter-parent/pom.xml
@@ -43,7 +43,7 @@
     </developers>
 
     <properties>
-        <java.version>1.10</java.version>
+        <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
Hey! very pleased to see this project while I was working on integrating tylerbenson's work.

This change targets java 1.8 so the jars in mavencentral can be pulled into projects pre-java 10.